### PR TITLE
Sample update and redo container move

### DIFF
--- a/fms_core/admin.py
+++ b/fms_core/admin.py
@@ -34,6 +34,7 @@ class ContainerAdmin(AggregatedAdmin):
     fieldsets = (
         (None, {"fields": ("kind", "name", "barcode")}),
         ("Parent Container", {"fields": ("location", "coordinates")}),
+        ("Additional information", {"fields": ("comment",)}),
     )
 
 

--- a/fms_core/example_data/sample_update.csv
+++ b/fms_core/example_data/sample_update.csv
@@ -6,6 +6,6 @@ Sample Update,,,,,,
 ,,,,,,
 #,Container Barcode,Coord (if plate),New Volume (uL),New Conc. (ng/uL),Depleted,Comment
 1,tube001,,0.001,0.001,False,sample moved
-2,
-3,
-4,
+2,,,,,,
+3,,,,,,
+4,,,,,,

--- a/fms_core/resources.py
+++ b/fms_core/resources.py
@@ -385,7 +385,6 @@ class ContainerMoveResource(GenericResource):
             obj.coordinates = data.get("Dest. Location Coord", "")
             # comment if empty does that mean that comment was removed? or not just not added
             obj.comment = data.get("Comment", container_to_move.comment)
-            #obj.save()
 
         else:
             super().import_field(field, obj, data, is_m2m)

--- a/fms_core/resources.py
+++ b/fms_core/resources.py
@@ -129,13 +129,15 @@ class SampleResource(GenericResource):
 
     # Non-attribute fields
     volume = Field(column_name='Volume (uL)', widget=DecimalWidget())
-    individual_name = Field(column_name='Individual Name')
-    sex = Field(column_name='Sex')
-    taxon = Field(column_name='Taxon')
+    # TODO don't really need it ?
+    # individual_name = Field(column_name='Individual Name')
+    sex = Field(attribute='sex', column_name='Sex')
+    taxon = Field(attribute='taxon', column_name='Taxon')
 
     # Computed fields
     coordinates = Field(attribute='coordinates')
-    individual = Field(attribute='individual', widget=ForeignKeyWidget(Individual, field='participant_id'))
+    individual = Field(attribute='individual', column_name="Individual Name",
+                       widget=ForeignKeyWidget(Individual, field='name'))
     volume_history = Field(attribute='volume_history', widget=JSONWidget())
 
     class Meta:
@@ -234,7 +236,7 @@ class ExtractionResource(GenericResource):
     alias = Field(attribute='alias')
     collection_site = Field(attribute='collection_site')
     container = Field(attribute='container', widget=ForeignKeyWidget(Container, field='barcode'))
-    individual = Field(attribute='individual', widget=ForeignKeyWidget(Individual, field='participant_id'))
+    individual = Field(attribute='individual', widget=ForeignKeyWidget(Individual, field='name'))
     extracted_from = Field(attribute='extracted_from', widget=ForeignKeyWidget(Sample, field='name'))
     volume_history = Field(attribute='volume_history', widget=JSONWidget())
 


### PR DESCRIPTION
 - Container move and sample updates are updates to existing objects, on import diff shows up - I find it as a very nice feature of django import-export but triggering this seems working only on 'id' field on import;
- small fixed in Individual: removed 'particpant_id' in resources since we remove it from db.

